### PR TITLE
Feat/mcp

### DIFF
--- a/packages/core/src/lib/components/Annotakit.svelte
+++ b/packages/core/src/lib/components/Annotakit.svelte
@@ -50,7 +50,7 @@
 		annotakitState.mcpServerUrl = mcpServerUrl ?? null;
 	});
 
-	// MCP health polling
+	// MCP health polling with backoff to avoid console noise when server is down
 	$effect(() => {
 		const url = annotakitState.mcpServerUrl;
 		if (!url || !mounted) {
@@ -59,22 +59,27 @@
 		}
 
 		let active = true;
+		let timeout: ReturnType<typeof setTimeout>;
+		const CONNECTED_INTERVAL = 5000;
+		const DISCONNECTED_INTERVAL = 30000;
 
 		async function check() {
 			try {
-				const res = await fetch(`${url.replace(/\/$/, '')}/api/health`, { signal: AbortSignal.timeout(3000) });
+				const res = await fetch(`${url!.replace(/\/$/, '')}/api/health`, { signal: AbortSignal.timeout(3000) });
 				if (active) annotakitState.mcpConnected = res.ok;
 			} catch {
 				if (active) annotakitState.mcpConnected = false;
 			}
+			if (active) {
+				timeout = setTimeout(check, annotakitState.mcpConnected ? CONNECTED_INTERVAL : DISCONNECTED_INTERVAL);
+			}
 		}
 
 		check();
-		const interval = setInterval(check, 5000);
 
 		return () => {
 			active = false;
-			clearInterval(interval);
+			clearTimeout(timeout);
 			annotakitState.mcpConnected = false;
 		};
 	});

--- a/packages/core/src/lib/components/Annotakit.svelte
+++ b/packages/core/src/lib/components/Annotakit.svelte
@@ -113,6 +113,14 @@
 		} catch { /* storage unavailable */ }
 	});
 
+	// Persist auto-clear setting
+	$effect(() => {
+		if (!mounted) return;
+		try {
+			localStorage.setItem(annotakitState.storageKey + ':auto-clear-after-copy', String(annotakitState.autoClearAfterCopy));
+		} catch { /* storage unavailable */ }
+	});
+
 	// Toggle crosshair cursor on body
 	$effect(() => {
 		if (!mounted) return;
@@ -162,6 +170,8 @@
 		try {
 			const savedBlock = localStorage.getItem(annotakitState.storageKey + ':block-interactions');
 			if (savedBlock === 'true') annotakitState.blockInteractions = true;
+			const savedAutoClear = localStorage.getItem(annotakitState.storageKey + ':auto-clear-after-copy');
+			if (savedAutoClear === 'true') annotakitState.autoClearAfterCopy = true;
 		} catch { /* storage unavailable */ }
 		document.addEventListener('keydown', handleKeyDown);
 		return () => {

--- a/packages/core/src/lib/components/Annotakit.svelte
+++ b/packages/core/src/lib/components/Annotakit.svelte
@@ -16,6 +16,7 @@
 		retentionDays?: number;
 		enabled?: boolean;
 		minimized?: boolean;
+		mcpServerUrl?: string;
 		onOutput?: (markdown: string) => void;
 	}
 
@@ -28,6 +29,7 @@
 		retentionDays = 7,
 		enabled = true,
 		minimized = false,
+		mcpServerUrl,
 		onOutput
 	}: Props = $props();
 
@@ -45,6 +47,36 @@
 		annotakitState.retentionDays = retentionDays;
 		annotakitState.enabled = enabled;
 		annotakitState.minimized = minimized;
+		annotakitState.mcpServerUrl = mcpServerUrl ?? null;
+	});
+
+	// MCP health polling
+	$effect(() => {
+		const url = annotakitState.mcpServerUrl;
+		if (!url || !mounted) {
+			annotakitState.mcpConnected = false;
+			return;
+		}
+
+		let active = true;
+
+		async function check() {
+			try {
+				const res = await fetch(`${url.replace(/\/$/, '')}/api/health`, { signal: AbortSignal.timeout(3000) });
+				if (active) annotakitState.mcpConnected = res.ok;
+			} catch {
+				if (active) annotakitState.mcpConnected = false;
+			}
+		}
+
+		check();
+		const interval = setInterval(check, 5000);
+
+		return () => {
+			active = false;
+			clearInterval(interval);
+			annotakitState.mcpConnected = false;
+		};
 	});
 
 	// Resolve theme and set data attribute

--- a/packages/core/src/lib/components/OutputDialog.svelte
+++ b/packages/core/src/lib/components/OutputDialog.svelte
@@ -25,6 +25,12 @@
 			copied = true;
 			onOutput?.(markdown);
 			setTimeout(() => (copied = false), 2000);
+			if (annotakitState.autoClearAfterCopy) {
+				setTimeout(() => {
+					annotakitState.clearAll();
+					closeDialog();
+				}, 500);
+			}
 		}
 	}
 

--- a/packages/core/src/lib/components/Toolbar.svelte
+++ b/packages/core/src/lib/components/Toolbar.svelte
@@ -94,6 +94,20 @@
 			</div>
 
 			<div class="space-y-2 p-3">
+				{#if annotakitState.mcpServerUrl}
+					<div class="flex items-center justify-between">
+						<div class="text-[10px] font-medium uppercase tracking-wider text-annotakit-text/50">MCP Server</div>
+						<div class="flex items-center gap-1.5">
+							<span class="text-[10px] text-annotakit-text/50">{annotakitState.mcpConnected ? 'Connected' : 'Disconnected'}</span>
+							<span
+								class="h-2 w-2 rounded-full {annotakitState.mcpConnected ? 'bg-green-500' : 'bg-annotakit-text/25'}"
+							></span>
+						</div>
+					</div>
+
+					<div class="h-px bg-annotakit-text/10"></div>
+				{/if}
+
 				<div>
 					<div class="mb-1 text-[10px] font-medium uppercase tracking-wider text-annotakit-text/50">Output format</div>
 					<div class="flex gap-2">

--- a/packages/core/src/lib/components/Toolbar.svelte
+++ b/packages/core/src/lib/components/Toolbar.svelte
@@ -71,6 +71,7 @@
 		if (ok) {
 			annotakitState.copyFeedback = true;
 			setTimeout(() => (annotakitState.copyFeedback = false), 1500);
+			if (annotakitState.autoClearAfterCopy) annotakitState.clearAll();
 		}
 	}
 </script>
@@ -157,6 +158,25 @@
 					>
 						<span
 							class="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform duration-300 ease-out {annotakitState.blockInteractions ? 'translate-x-4' : ''}"
+						></span>
+					</button>
+				</label>
+
+				<div class="h-px bg-annotakit-text/10"></div>
+
+				<label class="flex cursor-pointer items-center justify-between">
+					<span class="text-[10px] font-medium uppercase tracking-wider text-annotakit-text/50">Auto-clear after copy</span>
+					<button
+						role="switch"
+						aria-checked={annotakitState.autoClearAfterCopy}
+						aria-label="Clear annotations after export"
+						class="relative h-5 w-9 rounded-full border-2 border-annotakit-stroke transition-colors duration-300 ease-out {annotakitState.autoClearAfterCopy
+							? 'bg-annotakit-primary'
+							: 'bg-annotakit-text/15'}"
+						onclick={() => (annotakitState.autoClearAfterCopy = !annotakitState.autoClearAfterCopy)}
+					>
+						<span
+							class="absolute top-0.5 left-0.5 h-3 w-3 rounded-full bg-white transition-transform duration-300 ease-out {annotakitState.autoClearAfterCopy ? 'translate-x-4' : ''}"
 						></span>
 					</button>
 				</label>

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,4 +1,5 @@
 export { default as Annotakit } from './components/Annotakit.svelte';
+export { annotakitState } from './state.svelte.js';
 export type {
 	Annotation,
 	AnnotakitColor,

--- a/packages/core/src/lib/state.svelte.ts
+++ b/packages/core/src/lib/state.svelte.ts
@@ -35,6 +35,7 @@ class AnnotakitState {
 	theme = $state<AnnotakitTheme>('auto');
 	highlightColor = $state<AnnotakitColor>('green');
 	blockInteractions = $state(false);
+	autoClearAfterCopy = $state(false);
 	storageKey = $state('annotakit');
 	retentionDays = $state(7);
 

--- a/packages/core/src/lib/state.svelte.ts
+++ b/packages/core/src/lib/state.svelte.ts
@@ -38,6 +38,10 @@ class AnnotakitState {
 	storageKey = $state('annotakit');
 	retentionDays = $state(7);
 
+	// MCP
+	mcpServerUrl = $state<string | null>(null);
+	mcpConnected = $state(false);
+
 	// Transient UI
 	selectedAnnotationId = $state<string | null>(null);
 	showOutputDialog = $state(false);

--- a/packages/core/src/routes/+layout.svelte
+++ b/packages/core/src/routes/+layout.svelte
@@ -6,4 +6,4 @@
 </script>
 
 {@render children()}
-<Annotakit position="bottom-right" outputFormat="standard" theme="auto" />
+<Annotakit position="bottom-right" outputFormat="standard" theme="auto" mcpServerUrl="http://localhost:4156" />

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,143 @@
+# @annotakit/mcp
+
+MCP (Model Context Protocol) server for annotaKit. Exposes browser annotations to AI agents like Claude Desktop and Claude Code in real time.
+
+## How it works
+
+```
+Browser (annotaKit component)
+  -> HTTP POST /api/sessions/:id/sync
+  -> In-memory store (sessions + annotations with lifecycle status)
+  -> MCP tools (9 tools exposed to AI agents)
+  -> AI agent (Claude Desktop, Claude Code, etc.)
+```
+
+The browser bridge sends annotations to an HTTP server. The MCP server shares the same in-memory store and exposes the data to AI agents via stdio transport.
+
+## Setup
+
+### 1. Install
+
+```bash
+pnpm add @annotakit/mcp
+```
+
+### 2. Start the MCP server
+
+```bash
+npx @annotakit/mcp
+# or
+node node_modules/@annotakit/mcp/dist/bin.js
+```
+
+This starts:
+- HTTP server on port 4156 (for the browser bridge)
+- MCP server on stdio (for AI agents)
+
+Use `--port <number>` to change the HTTP port.
+
+### 3. Wire up the browser bridge
+
+In your Svelte layout (e.g. `+layout.svelte`):
+
+```svelte
+<script lang="ts">
+  import { Annotakit, annotakitState } from 'annotakit'
+  import { createMcpBridge } from '@annotakit/mcp/bridge'
+  import { browser } from '$app/environment'
+  import { onDestroy } from 'svelte'
+
+  const mcpBridge = browser ? createMcpBridge() : null
+
+  $effect(() => {
+    if (mcpBridge) {
+      mcpBridge.sync(annotakitState.annotations, window.location.href, document.title)
+    }
+  })
+
+  onDestroy(() => mcpBridge?.disconnect())
+</script>
+
+<Annotakit />
+```
+
+The bridge silently handles errors, so a missing MCP server never breaks your app.
+
+### 4. Connect an AI agent
+
+**Claude Code** - add to `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "annotakit": {
+      "command": "node",
+      "args": ["/path/to/node_modules/@annotakit/mcp/dist/bin.js"]
+    }
+  }
+}
+```
+
+**Claude Desktop** - add to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "annotakit": {
+      "command": "node",
+      "args": ["/path/to/node_modules/@annotakit/mcp/dist/bin.js"]
+    }
+  }
+}
+```
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `annotakit_list_sessions` | List active browser sessions |
+| `annotakit_get_session` | Get session details + annotation summary |
+| `annotakit_get_annotations` | Get annotations, filter by status, control detail level |
+| `annotakit_get_pending` | Get all pending annotations across sessions |
+| `annotakit_acknowledge` | Mark annotation as seen |
+| `annotakit_resolve` | Mark as addressed with optional summary |
+| `annotakit_dismiss` | Reject with reason |
+| `annotakit_reply` | Add agent response to annotation thread |
+| `annotakit_watch` | Long-poll until new annotations arrive |
+
+## Bridge API
+
+```typescript
+import { createMcpBridge } from '@annotakit/mcp/bridge'
+
+const bridge = createMcpBridge({
+  serverUrl: 'http://localhost:4156', // default
+  sessionId: 'custom-id',            // auto-generated if omitted
+})
+
+bridge.sync(annotations, url, title) // send annotations to MCP server
+bridge.disconnect()                   // notify server on unmount
+bridge.sessionId                      // read the session ID
+```
+
+## HTTP API
+
+```
+POST   /api/sessions/:sessionId/sync   - Receive annotations from browser
+DELETE /api/sessions/:sessionId         - Browser tab closing
+GET    /api/events?sessionId=           - SSE stream of annotation events
+GET    /api/health                      - Health check
+```
+
+## Testing
+
+```bash
+# Start the server
+node packages/mcp/dist/bin.js
+
+# Health check
+curl http://localhost:4156/api/health
+
+# Use the MCP Inspector
+npx @modelcontextprotocol/inspector node packages/mcp/dist/bin.js
+```

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,8 +1,36 @@
 {
   "name": "@annotakit/mcp",
   "version": "0.1.0",
-  "private": true,
-  "description": "MCP server for Annotakit (future)",
+  "description": "MCP server for annotaKit - exposes browser annotations to AI agents",
   "type": "module",
-  "license": "MIT"
+  "license": "MIT",
+  "bin": {
+    "annotakit-mcp": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    },
+    "./bridge": {
+      "types": "./dist/bridge.d.ts",
+      "default": "./dist/bridge.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0",
+    "@types/node": "^22.0.0",
+    "annotakit": "workspace:*"
+  }
 }

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { AnnotationStore } from './store.js';
+import { createMcpServer } from './server.js';
+import { createHttpServer } from './http/router.js';
+
+function parseArgs(args: string[]): { port: number } {
+	let port = 4156;
+	const portIndex = args.indexOf('--port');
+	if (portIndex !== -1 && args[portIndex + 1]) {
+		const parsed = parseInt(args[portIndex + 1], 10);
+		if (!isNaN(parsed) && parsed > 0 && parsed < 65536) {
+			port = parsed;
+		}
+	}
+	return { port };
+}
+
+async function main() {
+	const { port } = parseArgs(process.argv.slice(2));
+
+	// Shared store between HTTP and MCP
+	const store = new AnnotationStore();
+
+	// Start HTTP server for browser bridge
+	const httpServer = createHttpServer(store);
+	httpServer.listen(port, () => {
+		process.stderr.write(`annotaKit MCP: HTTP server listening on port ${port}\n`);
+	});
+
+	// Start MCP server on stdio
+	const mcpServer = createMcpServer(store);
+	const transport = new StdioServerTransport();
+	await mcpServer.connect(transport);
+
+	process.stderr.write('annotaKit MCP: MCP server running on stdio\n');
+
+	// Graceful shutdown
+	process.on('SIGINT', () => {
+		httpServer.close();
+		process.exit(0);
+	});
+	process.on('SIGTERM', () => {
+		httpServer.close();
+		process.exit(0);
+	});
+}
+
+main().catch((err) => {
+	process.stderr.write(`annotaKit MCP: Fatal error: ${err}\n`);
+	process.exit(1);
+});

--- a/packages/mcp/src/bridge.ts
+++ b/packages/mcp/src/bridge.ts
@@ -1,0 +1,70 @@
+/**
+ * Browser bridge for annotaKit MCP server.
+ * Import as '@annotakit/mcp/bridge' in your Svelte layout.
+ * This module is browser-safe and has no Node.js dependencies.
+ */
+
+import type { Annotation } from 'annotakit';
+
+export interface McpBridgeConfig {
+	/** MCP server URL. Default: 'http://localhost:4156' */
+	serverUrl?: string;
+	/** Session ID. Auto-generated if omitted. */
+	sessionId?: string;
+}
+
+export interface McpBridge {
+	/** Sync current annotations to the MCP server */
+	sync(annotations: Annotation[], url: string, title: string): Promise<void>;
+	/** Notify the MCP server that this session is disconnecting */
+	disconnect(): Promise<void>;
+	/** The session ID for this bridge instance */
+	readonly sessionId: string;
+}
+
+function generateId(): string {
+	if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+		return crypto.randomUUID();
+	}
+	// Fallback for older browsers
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+		const r = (Math.random() * 16) | 0;
+		const v = c === 'x' ? r : (r & 0x3) | 0x8;
+		return v.toString(16);
+	});
+}
+
+export function createMcpBridge(config?: McpBridgeConfig): McpBridge {
+	const serverUrl = (config?.serverUrl ?? 'http://localhost:4156').replace(/\/$/, '');
+	const sessionId = config?.sessionId ?? generateId();
+
+	async function sync(annotations: Annotation[], url: string, title: string): Promise<void> {
+		try {
+			await fetch(`${serverUrl}/api/sessions/${sessionId}/sync`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ url, title, annotations }),
+			});
+		} catch {
+			// Silently ignore - missing MCP server should never break the app
+		}
+	}
+
+	async function disconnect(): Promise<void> {
+		try {
+			await fetch(`${serverUrl}/api/sessions/${sessionId}`, {
+				method: 'DELETE',
+			});
+		} catch {
+			// Silently ignore
+		}
+	}
+
+	return {
+		sync,
+		disconnect,
+		get sessionId() {
+			return sessionId;
+		},
+	};
+}

--- a/packages/mcp/src/http/router.ts
+++ b/packages/mcp/src/http/router.ts
@@ -1,0 +1,123 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AnnotationStore } from '../store.js';
+import type { SyncPayload, StoreEvent } from '../types.js';
+
+function setCors(res: ServerResponse): void {
+	res.setHeader('Access-Control-Allow-Origin', '*');
+	res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+	res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}
+
+function json(res: ServerResponse, status: number, data: unknown): void {
+	setCors(res);
+	res.writeHead(status, { 'Content-Type': 'application/json' });
+	res.end(JSON.stringify(data));
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (chunk: Buffer) => chunks.push(chunk));
+		req.on('end', () => resolve(Buffer.concat(chunks).toString()));
+		req.on('error', reject);
+	});
+}
+
+function parseRoute(url: string): { path: string; params: Record<string, string>; query: Record<string, string> } {
+	const [pathname, queryString] = url.split('?');
+	const query: Record<string, string> = {};
+	if (queryString) {
+		for (const pair of queryString.split('&')) {
+			const [key, value] = pair.split('=');
+			if (key) query[decodeURIComponent(key)] = decodeURIComponent(value ?? '');
+		}
+	}
+
+	// Match /api/sessions/:sessionId/sync
+	const syncMatch = pathname.match(/^\/api\/sessions\/([^/]+)\/sync$/);
+	if (syncMatch) {
+		return { path: '/api/sessions/:sessionId/sync', params: { sessionId: syncMatch[1] }, query };
+	}
+
+	// Match /api/sessions/:sessionId
+	const sessionMatch = pathname.match(/^\/api\/sessions\/([^/]+)$/);
+	if (sessionMatch) {
+		return { path: '/api/sessions/:sessionId', params: { sessionId: sessionMatch[1] }, query };
+	}
+
+	return { path: pathname, params: {}, query };
+}
+
+export function createHttpServer(store: AnnotationStore) {
+	const server = createServer(async (req, res) => {
+		setCors(res);
+
+		// Handle CORS preflight
+		if (req.method === 'OPTIONS') {
+			res.writeHead(204);
+			res.end();
+			return;
+		}
+
+		const { path, params, query } = parseRoute(req.url ?? '/');
+
+		try {
+			// POST /api/sessions/:sessionId/sync
+			if (req.method === 'POST' && path === '/api/sessions/:sessionId/sync') {
+				const body = await readBody(req);
+				const payload: SyncPayload = JSON.parse(body);
+				store.syncAnnotations(params.sessionId, payload);
+				json(res, 200, { ok: true });
+				return;
+			}
+
+			// DELETE /api/sessions/:sessionId
+			if (req.method === 'DELETE' && path === '/api/sessions/:sessionId') {
+				const removed = store.removeSession(params.sessionId);
+				json(res, 200, { ok: true, removed });
+				return;
+			}
+
+			// GET /api/events
+			if (req.method === 'GET' && path === '/api/events') {
+				setCors(res);
+				res.writeHead(200, {
+					'Content-Type': 'text/event-stream',
+					'Cache-Control': 'no-cache',
+					'Connection': 'keep-alive',
+				});
+
+				const sessionFilter = query.sessionId;
+
+				const onEvent = (event: StoreEvent) => {
+					if (sessionFilter && event.sessionId !== sessionFilter) return;
+					res.write(`data: ${JSON.stringify(event)}\n\n`);
+				};
+
+				store.on('event', onEvent);
+
+				req.on('close', () => {
+					store.off('event', onEvent);
+				});
+				return;
+			}
+
+			// GET /api/health
+			if (req.method === 'GET' && path === '/api/health') {
+				json(res, 200, {
+					status: 'ok',
+					sessions: store.getAllSessions().length,
+					uptime: process.uptime(),
+				});
+				return;
+			}
+
+			// 404
+			json(res, 404, { error: 'Not found' });
+		} catch (err) {
+			json(res, 500, { error: err instanceof Error ? err.message : 'Internal server error' });
+		}
+	});
+
+	return server;
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,24 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { AnnotationStore } from './store.js';
+import { registerSessionTools } from './tools/sessions.js';
+import { registerAnnotationTools } from './tools/annotations.js';
+import { registerLifecycleTools } from './tools/lifecycle.js';
+import { registerWatchTool } from './tools/watch.js';
+
+export function createMcpServer(store: AnnotationStore): McpServer {
+	const server = new McpServer({
+		name: 'annotakit',
+		version: '0.1.0',
+	});
+
+	registerSessionTools(server, store);
+	registerAnnotationTools(server, store);
+	registerLifecycleTools(server, store);
+	registerWatchTool(server, store);
+
+	return server;
+}
+
+export { AnnotationStore } from './store.js';
+export { createHttpServer } from './http/router.js';
+export type * from './types.js';

--- a/packages/mcp/src/store.ts
+++ b/packages/mcp/src/store.ts
@@ -1,0 +1,210 @@
+import { EventEmitter } from 'node:events';
+import type {
+	McpAnnotation,
+	Session,
+	SyncPayload,
+	AnnotationStatus,
+	AnnotationReply,
+	StoreEvent,
+} from './types.js';
+
+export class AnnotationStore extends EventEmitter {
+	private sessions = new Map<string, Session>();
+	private annotations = new Map<string, McpAnnotation>();
+
+	syncAnnotations(sessionId: string, payload: SyncPayload): void {
+		const now = Date.now();
+
+		// Create or update session
+		let session = this.sessions.get(sessionId);
+		if (!session) {
+			session = {
+				id: sessionId,
+				createdAt: now,
+				lastActivityAt: now,
+				url: payload.url,
+				title: payload.title,
+				annotationCount: 0,
+			};
+			this.sessions.set(sessionId, session);
+			this.emit('event', {
+				type: 'session:created',
+				sessionId,
+				data: session,
+			} satisfies StoreEvent);
+		} else {
+			session.lastActivityAt = now;
+			session.url = payload.url;
+			session.title = payload.title;
+		}
+
+		// Track incoming annotation IDs
+		const incomingIds = new Set(payload.annotations.map((a) => a.id));
+
+		// Remove annotations no longer present in browser
+		for (const [id, existing] of this.annotations) {
+			if (existing.sessionId === sessionId && !incomingIds.has(id)) {
+				this.annotations.delete(id);
+				this.emit('event', {
+					type: 'annotation:removed',
+					sessionId,
+					annotationId: id,
+				} satisfies StoreEvent);
+			}
+		}
+
+		// Add or update annotations
+		for (const incoming of payload.annotations) {
+			const existing = this.annotations.get(incoming.id);
+			if (existing) {
+				// Update core fields from browser, preserve lifecycle state
+				existing.element = incoming.element;
+				existing.elements = incoming.elements;
+				existing.textSelection = incoming.textSelection;
+				existing.comment = incoming.comment;
+				this.emit('event', {
+					type: 'annotation:updated',
+					sessionId,
+					annotationId: incoming.id,
+					data: existing,
+				} satisfies StoreEvent);
+			} else {
+				const annotation: McpAnnotation = {
+					...incoming,
+					sessionId,
+					status: 'pending',
+					replies: [],
+				};
+				this.annotations.set(incoming.id, annotation);
+				this.emit('event', {
+					type: 'annotation:added',
+					sessionId,
+					annotationId: incoming.id,
+					data: annotation,
+				} satisfies StoreEvent);
+			}
+		}
+
+		// Update session annotation count
+		session.annotationCount = this.getSessionAnnotations(sessionId).length;
+		this.emit('event', {
+			type: 'session:updated',
+			sessionId,
+			data: session,
+		} satisfies StoreEvent);
+	}
+
+	removeSession(sessionId: string): boolean {
+		const session = this.sessions.get(sessionId);
+		if (!session) return false;
+
+		// Remove all annotations for this session
+		for (const [id, annotation] of this.annotations) {
+			if (annotation.sessionId === sessionId) {
+				this.annotations.delete(id);
+			}
+		}
+
+		this.sessions.delete(sessionId);
+		return true;
+	}
+
+	getSession(sessionId: string): Session | undefined {
+		return this.sessions.get(sessionId);
+	}
+
+	getAllSessions(): Session[] {
+		return Array.from(this.sessions.values());
+	}
+
+	getAnnotation(annotationId: string): McpAnnotation | undefined {
+		return this.annotations.get(annotationId);
+	}
+
+	getSessionAnnotations(sessionId: string, status?: AnnotationStatus): McpAnnotation[] {
+		const results: McpAnnotation[] = [];
+		for (const annotation of this.annotations.values()) {
+			if (annotation.sessionId === sessionId) {
+				if (!status || annotation.status === status) {
+					results.push(annotation);
+				}
+			}
+		}
+		return results;
+	}
+
+	getPendingAnnotations(sessionId?: string): McpAnnotation[] {
+		const results: McpAnnotation[] = [];
+		for (const annotation of this.annotations.values()) {
+			if (annotation.status === 'pending') {
+				if (!sessionId || annotation.sessionId === sessionId) {
+					results.push(annotation);
+				}
+			}
+		}
+		return results;
+	}
+
+	acknowledge(annotationId: string): McpAnnotation | undefined {
+		const annotation = this.annotations.get(annotationId);
+		if (!annotation) return undefined;
+		annotation.status = 'acknowledged';
+		annotation.acknowledgedAt = Date.now();
+		this.emit('event', {
+			type: 'annotation:updated',
+			sessionId: annotation.sessionId,
+			annotationId,
+			data: annotation,
+		} satisfies StoreEvent);
+		return annotation;
+	}
+
+	resolve(annotationId: string, summary?: string): McpAnnotation | undefined {
+		const annotation = this.annotations.get(annotationId);
+		if (!annotation) return undefined;
+		annotation.status = 'resolved';
+		annotation.resolvedAt = Date.now();
+		if (summary) annotation.resolutionSummary = summary;
+		this.emit('event', {
+			type: 'annotation:updated',
+			sessionId: annotation.sessionId,
+			annotationId,
+			data: annotation,
+		} satisfies StoreEvent);
+		return annotation;
+	}
+
+	dismiss(annotationId: string, reason: string): McpAnnotation | undefined {
+		const annotation = this.annotations.get(annotationId);
+		if (!annotation) return undefined;
+		annotation.status = 'dismissed';
+		annotation.dismissedAt = Date.now();
+		annotation.dismissReason = reason;
+		this.emit('event', {
+			type: 'annotation:updated',
+			sessionId: annotation.sessionId,
+			annotationId,
+			data: annotation,
+		} satisfies StoreEvent);
+		return annotation;
+	}
+
+	addReply(annotationId: string, message: string, source: 'agent' | 'user' = 'agent'): McpAnnotation | undefined {
+		const annotation = this.annotations.get(annotationId);
+		if (!annotation) return undefined;
+		const reply: AnnotationReply = {
+			id: crypto.randomUUID(),
+			timestamp: Date.now(),
+			source,
+			message,
+		};
+		annotation.replies.push(reply);
+		this.emit('event', {
+			type: 'annotation:updated',
+			sessionId: annotation.sessionId,
+			annotationId,
+			data: annotation,
+		} satisfies StoreEvent);
+		return annotation;
+	}
+}

--- a/packages/mcp/src/tools/annotations.ts
+++ b/packages/mcp/src/tools/annotations.ts
@@ -1,0 +1,104 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AnnotationStore } from '../store.js';
+import type { McpAnnotation, AnnotationStatus } from '../types.js';
+
+type Format = 'compact' | 'standard' | 'detailed';
+
+function formatAnnotation(a: McpAnnotation, format: Format): Record<string, unknown> {
+	if (format === 'compact') {
+		return {
+			id: a.id,
+			status: a.status,
+			mode: a.mode,
+			comment: a.comment,
+			selector: a.element.selector,
+			repliesCount: a.replies.length,
+		};
+	}
+
+	if (format === 'standard') {
+		return {
+			id: a.id,
+			timestamp: a.timestamp,
+			status: a.status,
+			mode: a.mode,
+			comment: a.comment,
+			element: {
+				tagName: a.element.tagName,
+				selector: a.element.selector,
+				classes: a.element.classes,
+				id: a.element.id,
+				textContent: a.element.textContent,
+			},
+			textSelection: a.textSelection,
+			replies: a.replies,
+			resolutionSummary: a.resolutionSummary,
+			dismissReason: a.dismissReason,
+		};
+	}
+
+	// detailed - return everything
+	return { ...a };
+}
+
+export function registerAnnotationTools(server: McpServer, store: AnnotationStore): void {
+	server.tool(
+		'annotakit_get_annotations',
+		'Get annotations for a session, optionally filtered by status. Use format to control detail level.',
+		{
+			sessionId: z.string().describe('The session ID'),
+			status: z.enum(['pending', 'acknowledged', 'resolved', 'dismissed']).optional().describe('Filter by annotation status'),
+			format: z.enum(['compact', 'standard', 'detailed']).default('standard').describe('Output detail level'),
+		},
+		async ({ sessionId, status, format }) => {
+			const session = store.getSession(sessionId);
+			if (!session) {
+				return { content: [{ type: 'text', text: `Session "${sessionId}" not found.` }] };
+			}
+
+			const annotations = store.getSessionAnnotations(sessionId, status as AnnotationStatus | undefined);
+			if (annotations.length === 0) {
+				const statusMsg = status ? ` with status "${status}"` : '';
+				return { content: [{ type: 'text', text: `No annotations${statusMsg} in session "${sessionId}".` }] };
+			}
+
+			const formatted = annotations.map((a) => formatAnnotation(a, format as Format));
+			return {
+				content: [{
+					type: 'text',
+					text: JSON.stringify(formatted, null, 2),
+				}],
+			};
+		},
+	);
+
+	server.tool(
+		'annotakit_get_pending',
+		'Get all pending annotations across all sessions (or for a specific session)',
+		{
+			sessionId: z.string().optional().describe('Optional session ID to filter by'),
+		},
+		async ({ sessionId }) => {
+			const pending = store.getPendingAnnotations(sessionId);
+			if (pending.length === 0) {
+				return { content: [{ type: 'text', text: 'No pending annotations.' }] };
+			}
+
+			const formatted = pending.map((a) => ({
+				id: a.id,
+				sessionId: a.sessionId,
+				mode: a.mode,
+				comment: a.comment,
+				selector: a.element.selector,
+				timestamp: a.timestamp,
+			}));
+			return {
+				content: [{
+					type: 'text',
+					text: JSON.stringify(formatted, null, 2),
+				}],
+			};
+		},
+	);
+}

--- a/packages/mcp/src/tools/lifecycle.ts
+++ b/packages/mcp/src/tools/lifecycle.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AnnotationStore } from '../store.js';
+
+export function registerLifecycleTools(server: McpServer, store: AnnotationStore): void {
+	server.tool(
+		'annotakit_acknowledge',
+		'Mark an annotation as acknowledged (seen by the agent)',
+		{ annotationId: z.string().describe('The annotation ID to acknowledge') },
+		async ({ annotationId }) => {
+			const result = store.acknowledge(annotationId);
+			if (!result) {
+				return { content: [{ type: 'text', text: `Annotation "${annotationId}" not found.` }] };
+			}
+			return {
+				content: [{ type: 'text', text: `Acknowledged annotation "${annotationId}".` }],
+			};
+		},
+	);
+
+	server.tool(
+		'annotakit_resolve',
+		'Mark an annotation as resolved (addressed by the agent)',
+		{
+			annotationId: z.string().describe('The annotation ID to resolve'),
+			summary: z.string().optional().describe('Optional summary of how the annotation was addressed'),
+		},
+		async ({ annotationId, summary }) => {
+			const result = store.resolve(annotationId, summary);
+			if (!result) {
+				return { content: [{ type: 'text', text: `Annotation "${annotationId}" not found.` }] };
+			}
+			return {
+				content: [{
+					type: 'text',
+					text: `Resolved annotation "${annotationId}".${summary ? ` Summary: ${summary}` : ''}`,
+				}],
+			};
+		},
+	);
+
+	server.tool(
+		'annotakit_dismiss',
+		'Dismiss an annotation with a reason',
+		{
+			annotationId: z.string().describe('The annotation ID to dismiss'),
+			reason: z.string().describe('Reason for dismissing the annotation'),
+		},
+		async ({ annotationId, reason }) => {
+			const result = store.dismiss(annotationId, reason);
+			if (!result) {
+				return { content: [{ type: 'text', text: `Annotation "${annotationId}" not found.` }] };
+			}
+			return {
+				content: [{
+					type: 'text',
+					text: `Dismissed annotation "${annotationId}". Reason: ${reason}`,
+				}],
+			};
+		},
+	);
+
+	server.tool(
+		'annotakit_reply',
+		'Add a reply message to an annotation thread',
+		{
+			annotationId: z.string().describe('The annotation ID to reply to'),
+			message: z.string().describe('The reply message'),
+		},
+		async ({ annotationId, message }) => {
+			const result = store.addReply(annotationId, message, 'agent');
+			if (!result) {
+				return { content: [{ type: 'text', text: `Annotation "${annotationId}" not found.` }] };
+			}
+			return {
+				content: [{
+					type: 'text',
+					text: `Reply added to annotation "${annotationId}". Thread now has ${result.replies.length} ${result.replies.length === 1 ? 'reply' : 'replies'}.`,
+				}],
+			};
+		},
+	);
+}

--- a/packages/mcp/src/tools/sessions.ts
+++ b/packages/mcp/src/tools/sessions.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AnnotationStore } from '../store.js';
+
+export function registerSessionTools(server: McpServer, store: AnnotationStore): void {
+	server.tool(
+		'annotakit_list_sessions',
+		'List all active browser sessions connected to annotaKit',
+		{},
+		async () => {
+			const sessions = store.getAllSessions();
+			if (sessions.length === 0) {
+				return { content: [{ type: 'text', text: 'No active sessions. Make sure the annotaKit bridge is running in your browser.' }] };
+			}
+			return {
+				content: [{
+					type: 'text',
+					text: JSON.stringify(sessions, null, 2),
+				}],
+			};
+		},
+	);
+
+	server.tool(
+		'annotakit_get_session',
+		'Get details for a specific browser session including annotation summary',
+		{ sessionId: z.string().describe('The session ID to look up') },
+		async ({ sessionId }) => {
+			const session = store.getSession(sessionId);
+			if (!session) {
+				return { content: [{ type: 'text', text: `Session "${sessionId}" not found.` }] };
+			}
+
+			const annotations = store.getSessionAnnotations(sessionId);
+			const statusCounts = {
+				pending: 0,
+				acknowledged: 0,
+				resolved: 0,
+				dismissed: 0,
+			};
+			for (const a of annotations) {
+				statusCounts[a.status]++;
+			}
+
+			return {
+				content: [{
+					type: 'text',
+					text: JSON.stringify({ ...session, statusCounts }, null, 2),
+				}],
+			};
+		},
+	);
+}

--- a/packages/mcp/src/tools/watch.ts
+++ b/packages/mcp/src/tools/watch.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { AnnotationStore } from '../store.js';
+import type { StoreEvent } from '../types.js';
+
+export function registerWatchTool(server: McpServer, store: AnnotationStore): void {
+	server.tool(
+		'annotakit_watch',
+		'Long-poll for new annotation events. Blocks until a new annotation arrives or timeout is reached.',
+		{
+			sessionId: z.string().optional().describe('Optional session ID to watch'),
+			timeoutSeconds: z.number().min(1).max(120).default(30).describe('Timeout in seconds (default 30, max 120)'),
+		},
+		async ({ sessionId, timeoutSeconds }) => {
+			const timeout = (timeoutSeconds ?? 30) * 1000;
+
+			const result = await new Promise<StoreEvent | null>((resolve) => {
+				const timer = setTimeout(() => {
+					store.off('event', onEvent);
+					resolve(null);
+				}, timeout);
+
+				function onEvent(event: StoreEvent) {
+					if (event.type !== 'annotation:added') return;
+					if (sessionId && event.sessionId !== sessionId) return;
+					clearTimeout(timer);
+					store.off('event', onEvent);
+					resolve(event);
+				}
+
+				store.on('event', onEvent);
+			});
+
+			if (!result) {
+				return {
+					content: [{ type: 'text', text: `No new annotations within ${timeoutSeconds ?? 30}s timeout.` }],
+				};
+			}
+
+			return {
+				content: [{
+					type: 'text',
+					text: JSON.stringify({
+						event: result.type,
+						sessionId: result.sessionId,
+						annotationId: result.annotationId,
+						annotation: result.data,
+					}, null, 2),
+				}],
+			};
+		},
+	);
+}

--- a/packages/mcp/src/types.ts
+++ b/packages/mcp/src/types.ts
@@ -1,0 +1,115 @@
+export type AnnotationStatus = 'pending' | 'acknowledged' | 'resolved' | 'dismissed';
+
+export interface SerializedRect {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface SerializedComputedStyles {
+	color: string;
+	backgroundColor: string;
+	fontSize: string;
+	fontFamily: string;
+	fontWeight: string;
+	lineHeight: string;
+	padding: string;
+	margin: string;
+	borderRadius: string;
+	border: string;
+	display: string;
+	position: string;
+	width: string;
+	height: string;
+}
+
+export interface SerializedAccessibility {
+	role?: string;
+	ariaLabel?: string;
+	ariaDescribedBy?: string;
+	tabIndex?: number;
+	alt?: string;
+}
+
+export interface SerializedSvelteComponent {
+	name: string;
+	file: string;
+	line?: number;
+	col?: number;
+	chain: string[];
+}
+
+export interface SerializedElementInfo {
+	tagName: string;
+	classes: string[];
+	id?: string;
+	selector: string;
+	rect: SerializedRect;
+	styles: SerializedComputedStyles;
+	accessibility: SerializedAccessibility;
+	svelte?: SerializedSvelteComponent;
+	textContent?: string;
+}
+
+export interface SerializedTextSelection {
+	text: string;
+	contextBefore: string;
+	contextAfter: string;
+	anchorSelector: string;
+}
+
+export interface AnnotationReply {
+	id: string;
+	timestamp: number;
+	source: 'agent' | 'user';
+	message: string;
+}
+
+export interface McpAnnotation {
+	id: string;
+	timestamp: number;
+	mode: 'element' | 'text' | 'multi';
+	element: SerializedElementInfo;
+	elements?: SerializedElementInfo[];
+	textSelection?: SerializedTextSelection;
+	comment: string;
+	sessionId: string;
+	status: AnnotationStatus;
+	acknowledgedAt?: number;
+	resolvedAt?: number;
+	dismissedAt?: number;
+	resolutionSummary?: string;
+	dismissReason?: string;
+	replies: AnnotationReply[];
+}
+
+export interface Session {
+	id: string;
+	createdAt: number;
+	lastActivityAt: number;
+	url: string;
+	title: string;
+	annotationCount: number;
+}
+
+export interface SyncPayload {
+	url: string;
+	title: string;
+	annotations: Array<{
+		id: string;
+		timestamp: number;
+		mode: 'element' | 'text' | 'multi';
+		element: SerializedElementInfo;
+		elements?: SerializedElementInfo[];
+		textSelection?: SerializedTextSelection;
+		comment: string;
+	}>;
+}
+
+export interface StoreEvent {
+	type: 'annotation:added' | 'annotation:updated' | 'annotation:removed' | 'session:created' | 'session:updated';
+	sessionId: string;
+	annotationId?: string;
+	data?: McpAnnotation | Session;
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,24 @@ importers:
         specifier: ^6.3.0
         version: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)
 
-  packages/mcp: {}
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.27.1(zod@3.25.76)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      annotakit:
+        specifier: workspace:*
+        version: link:../core
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
 
 packages:
 
@@ -256,6 +273,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@internationalized/date@3.11.0':
     resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
 
@@ -274,6 +297,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -644,16 +677,34 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@22.19.15':
+    resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
   '@types/node@25.3.3':
     resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -670,6 +721,22 @@ packages:
       '@internationalized/date': ^3.8.1
       svelte: ^5.33.0
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -682,9 +749,33 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -702,6 +793,10 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -713,20 +808,74 @@ packages:
   devalue@5.6.3:
     resolution: {integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
     engines: {node: '>=10.13.0'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   esrap@2.2.3:
     resolution: {integrity: sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.3.1:
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -737,16 +886,74 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.7:
+    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -756,12 +963,27 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.1:
+    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -847,6 +1069,26 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -863,8 +1105,38 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -873,9 +1145,29 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -885,10 +1177,18 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   runed@0.23.4:
     resolution: {integrity: sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA==}
@@ -908,6 +1208,9 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
@@ -916,8 +1219,43 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@3.0.1:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -926,6 +1264,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
@@ -974,6 +1316,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -981,13 +1327,28 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vaul-svelte@1.0.0-next.7:
     resolution: {integrity: sha512-7zN7Bi3dFQixvvbUJY9uGDe7Ws/dGZeBQR2pXdXmzQiakjrxBvWo0QrmsX3HK+VH+SZOltz378cmgmCS9f9rSg==}
@@ -1043,8 +1404,24 @@ packages:
       vite:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1137,6 +1514,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@hono/node-server@1.19.11(hono@4.12.7)':
+    dependencies:
+      hono: 4.12.7
+
   '@internationalized/date@3.11.0':
     dependencies:
       '@swc/helpers': 0.5.19
@@ -1159,6 +1540,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.7)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.7
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -1450,13 +1853,33 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@22.19.15':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.3.3':
     dependencies:
       undici-types: 7.18.2
 
   '@types/trusted-types@2.0.7': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   aria-query@5.3.1: {}
 
@@ -1475,6 +1898,32 @@ snapshots:
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -1485,7 +1934,26 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.2.2: {}
+
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.3:
     dependencies:
@@ -1495,16 +1963,36 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   devalue@5.6.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
   enhanced-resolve@5.20.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1535,22 +2023,137 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  escape-html@1.0.3: {}
+
   esm-env@1.2.2: {}
 
   esrap@2.2.3:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
+  express-rate-limit@8.3.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.0: {}
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.7: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.7: {}
+
+  ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -1558,11 +2161,21 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-promise@4.0.0: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  isexe@2.0.0: {}
+
   jiti@2.6.1: {}
+
+  jose@6.2.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   kleur@4.1.5: {}
 
@@ -1623,6 +2236,18 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -1631,11 +2256,33 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   node-addon-api@7.1.1: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.3.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.6:
     dependencies:
@@ -1643,9 +2290,29 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
+
+  require-from-string@2.0.2: {}
 
   rollup@4.59.0:
     dependencies:
@@ -1678,6 +2345,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   runed@0.23.4(svelte@5.53.6):
     dependencies:
       esm-env: 1.2.2
@@ -1696,11 +2373,74 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safer-buffer@2.1.2: {}
+
   scule@1.3.0: {}
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@3.0.1: {}
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   sirv@3.0.2:
     dependencies:
@@ -1709,6 +2449,8 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  statuses@2.0.2: {}
 
   style-to-object@1.0.14:
     dependencies:
@@ -1779,13 +2521,27 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tslib@2.8.1: {}
 
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.18.2: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
 
   vaul-svelte@1.0.0-next.7(svelte@5.53.6):
     dependencies:
@@ -1811,4 +2567,16 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrappy@1.0.2: {}
+
   zimmerframe@1.1.4: {}
+
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## What changed?

 - New `@annotakit/mcp` package with an HTTP server, in-memory annotation store, and 9 MCP tools for AI agent integration
 - Browser bridge (`@annotakit/mcp/bridge`) that syncs annotations to the MCP server via fetch
 - MCP server status indicator (green/grey dot) in the settings panel, visible when `mcpServerUrl` prop is set
 - Auto-clear after copy toggle in settings, clears annotations after copying markdown
 - Exported `annotakitState` from core package


## Why?

Enables AI agents (Claude Desktop, Claude Code, etc.) to receive, process, and respond to browser annotations in real time via the Model Context Protocol. Users annotate UI elements in the browser, and agents can read, acknowledge, resolve, dismiss, and reply to those annotations through MCP tools.

Closes #12

## Screenshots / GIF

<img width="624" height="652" alt="image" src="https://github.com/user-attachments/assets/6ad75969-614d-4632-a141-4c68ec8fe8b9" />

## Breaking changes

None

## How was this tested?

- Started MCP server (`node packages/mcp/dist/bin.js`), verified HTTP health endpoint
- Synced annotations from browser via the bridge, confirmed sessions appeared in health response
- Tested all 9 MCP tools through the MCP Inspector (list sessions, get pending, acknowledge, reply, resolve, etc.)
- Verified settings panel shows green dot when MCP server is running, grey when stopped
- Verified auto-clear after copy toggle clears annotations in both toolbar copy and output dialog

## Checklist

- [x] Code follows the project's style and conventions
- [x] Changes have been tested locally
- [x] Documentation has been updated (if applicable)
